### PR TITLE
Configure specific ip address to accept connections from

### DIFF
--- a/example/src/main.cpp
+++ b/example/src/main.cpp
@@ -14,7 +14,7 @@ int main() {
 
   // Create an FTP Server on port 2121. We use 2121 instead of the default port
   // 21, as your application would need root privileges to open port 21.
-  fineftp::FtpServer server(2121);
+  fineftp::FtpServer server(2121, "127.0.0.1");
 
   // Add the well known anonymous user and some normal users. The anonymous user
   // can log in with username "anonyous" or "ftp" and any password. The normal

--- a/example/src/main.cpp
+++ b/example/src/main.cpp
@@ -14,7 +14,7 @@ int main() {
 
   // Create an FTP Server on port 2121. We use 2121 instead of the default port
   // 21, as your application would need root privileges to open port 21.
-  fineftp::FtpServer server(2121, "127.0.0.1");
+  fineftp::FtpServer server(2121);
 
   // Add the well known anonymous user and some normal users. The anonymous user
   // can log in with username "anonyous" or "ftp" and any password. The normal

--- a/fineftp-server/include/fineftp/server.h
+++ b/fineftp-server/include/fineftp/server.h
@@ -44,8 +44,9 @@ namespace fineftp
      * can be determined by with getPort().
      * 
      * @param port: The port to start the FTP server on. Defaults to 21.
+     * @param host: The host to accept incoming connections from. Defaults to "0.0.0.0"
      */
-    FtpServer(uint16_t port = 21);
+    FtpServer(uint16_t port = 21, std::string host = "0.0.0.0");
 
     ~FtpServer();
 
@@ -117,6 +118,13 @@ namespace fineftp
      * @return The control port the server is listening on
      */
     uint16_t getPort() const;
+
+    /**
+     * @brief Get the host that the FTP server is listening on
+     * 
+     * @return The host the server is listening on
+     */
+    std::string getHost() const;
 
     // Non-copyable
     FtpServer(const FtpServer&) = delete;

--- a/fineftp-server/include/fineftp/server.h
+++ b/fineftp-server/include/fineftp/server.h
@@ -46,7 +46,7 @@ namespace fineftp
      * @param port: The port to start the FTP server on. Defaults to 21.
      * @param host: The host to accept incoming connections from. Defaults to "0.0.0.0"
      */
-    FtpServer(uint16_t port = 21, std::string host = "0.0.0.0");
+    FtpServer(uint16_t port = 21, const std::string& address = "0.0.0.0");
 
     ~FtpServer();
 
@@ -120,11 +120,11 @@ namespace fineftp
     uint16_t getPort() const;
 
     /**
-     * @brief Get the host that the FTP server is listening on
+     * @brief Get the ip address that the FTP server is listening for.
      * 
-     * @return The host the server is listening on
+     * @return The ip address the FTP server is listening for.
      */
-    std::string getHost() const;
+    std::string getAddress() const;
 
     // Non-copyable
     FtpServer(const FtpServer&) = delete;

--- a/fineftp-server/src/server.cpp
+++ b/fineftp-server/src/server.cpp
@@ -5,8 +5,8 @@
 
 namespace fineftp
 {
-  FtpServer::FtpServer(uint16_t port)
-    : ftp_server_(std::make_unique<FtpServerImpl>(port))
+  FtpServer::FtpServer(uint16_t port, std::string host)
+    : ftp_server_(std::make_unique<FtpServerImpl>(port, host))
   {}
 
   FtpServer::~FtpServer()
@@ -41,5 +41,10 @@ namespace fineftp
   uint16_t FtpServer::getPort() const
   {
     return ftp_server_->getPort();
+  }
+
+  std::string FtpServer::getHost() const
+  {
+    return ftp_server_->getHost();
   }
 }

--- a/fineftp-server/src/server.cpp
+++ b/fineftp-server/src/server.cpp
@@ -5,8 +5,8 @@
 
 namespace fineftp
 {
-  FtpServer::FtpServer(uint16_t port, std::string host)
-    : ftp_server_(std::make_unique<FtpServerImpl>(port, host))
+  FtpServer::FtpServer(uint16_t port, const std::string& address)
+    : ftp_server_(std::make_unique<FtpServerImpl>(port, address))
   {}
 
   FtpServer::~FtpServer()
@@ -43,8 +43,8 @@ namespace fineftp
     return ftp_server_->getPort();
   }
 
-  std::string FtpServer::getHost() const
+  std::string FtpServer::getAddress() const
   {
-    return ftp_server_->getHost();
+    return ftp_server_->getAddress();
   }
 }

--- a/fineftp-server/src/server_impl.cpp
+++ b/fineftp-server/src/server_impl.cpp
@@ -8,9 +8,9 @@
 namespace fineftp
 {
 
-  FtpServerImpl::FtpServerImpl(uint16_t port, std::string host)
+  FtpServerImpl::FtpServerImpl(uint16_t port, const std::string& address)
     : port_                 (port)
-    , host_                 (host)
+    , address_              (address)
     , acceptor_             (io_service_)
     , open_connection_count_(0)
   {}
@@ -35,7 +35,7 @@ namespace fineftp
     auto ftp_session = std::make_shared<FtpSession>(io_service_, ftp_users_, [this]() { open_connection_count_--; });
 
     // set up the acceptor to listen on the tcp port
-    asio::ip::tcp::endpoint endpoint(asio::ip::make_address(host_), port_);
+    asio::ip::tcp::endpoint endpoint(asio::ip::make_address(address_), port_);
     
     {
       asio::error_code ec;
@@ -143,7 +143,7 @@ namespace fineftp
     return acceptor_.local_endpoint().port();
   }
 
-  std::string FtpServerImpl::getHost()
+  std::string FtpServerImpl::getAddress()
   {
     return acceptor_.local_endpoint().address().to_string();
   }

--- a/fineftp-server/src/server_impl.cpp
+++ b/fineftp-server/src/server_impl.cpp
@@ -8,8 +8,9 @@
 namespace fineftp
 {
 
-  FtpServerImpl::FtpServerImpl(uint16_t port)
+  FtpServerImpl::FtpServerImpl(uint16_t port, std::string host)
     : port_                 (port)
+    , host_                 (host)
     , acceptor_             (io_service_)
     , open_connection_count_(0)
   {}
@@ -34,7 +35,7 @@ namespace fineftp
     auto ftp_session = std::make_shared<FtpSession>(io_service_, ftp_users_, [this]() { open_connection_count_--; });
 
     // set up the acceptor to listen on the tcp port
-    asio::ip::tcp::endpoint endpoint(asio::ip::tcp::v4(), port_);
+    asio::ip::tcp::endpoint endpoint(asio::ip::make_address(host_), port_);
     
     {
       asio::error_code ec;
@@ -77,7 +78,7 @@ namespace fineftp
     }
     
 #ifndef NDEBUG
-    std::cout << "FTP Server created. Listening on port " << acceptor_.local_endpoint().port() << std::endl;
+    std::cout << "FTP Server created." << std::endl << "Listening at address " << acceptor_.local_endpoint().address() << " on port " << acceptor_.local_endpoint().port() << ":" << std::endl;
 #endif // NDEBUG
 
     acceptor_.async_accept(ftp_session->getSocket()
@@ -140,5 +141,10 @@ namespace fineftp
   uint16_t FtpServerImpl::getPort()
   {
     return acceptor_.local_endpoint().port();
+  }
+
+  std::string FtpServerImpl::getHost()
+  {
+    return acceptor_.local_endpoint().address().to_string();
   }
 }

--- a/fineftp-server/src/server_impl.h
+++ b/fineftp-server/src/server_impl.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vector>
+#include <string>
 #include <thread>
 #include <atomic>
 
@@ -16,7 +17,7 @@ namespace fineftp
   class FtpServerImpl
   {
   public:
-    FtpServerImpl(uint16_t port);
+    FtpServerImpl(uint16_t port, std::string host);
 
     ~FtpServerImpl();
 
@@ -31,6 +32,8 @@ namespace fineftp
 
     uint16_t getPort(); 
 
+    std::string getHost();
+
   private:
     void acceptFtpSession(std::shared_ptr<FtpSession> ftp_session, asio::error_code const& error);
 
@@ -38,6 +41,7 @@ namespace fineftp
     UserDatabase   ftp_users_;
 
     const uint16_t port_;
+    const std::string host_;
 
     std::vector<std::thread> thread_pool_;
     asio::io_service         io_service_;

--- a/fineftp-server/src/server_impl.h
+++ b/fineftp-server/src/server_impl.h
@@ -17,7 +17,7 @@ namespace fineftp
   class FtpServerImpl
   {
   public:
-    FtpServerImpl(uint16_t port, std::string host);
+    FtpServerImpl(uint16_t port, const std::string& address);
 
     ~FtpServerImpl();
 
@@ -32,7 +32,7 @@ namespace fineftp
 
     uint16_t getPort(); 
 
-    std::string getHost();
+    std::string getAddress();
 
   private:
     void acceptFtpSession(std::shared_ptr<FtpSession> ftp_session, asio::error_code const& error);
@@ -41,7 +41,7 @@ namespace fineftp
     UserDatabase   ftp_users_;
 
     const uint16_t port_;
-    const std::string host_;
+    const std::string address_;
 
     std::vector<std::thread> thread_pool_;
     asio::io_service         io_service_;


### PR DESCRIPTION
__Description__
Server can be instantiated binding to a specific ipv4 or ipv6 address as per issue #2.