### PR TITLE
Fixed race condition when closing file

### DIFF
--- a/fineftp-server/src/ftp_session.cpp
+++ b/fineftp-server/src/ftp_session.cpp
@@ -1066,7 +1066,7 @@ namespace fineftp
                           {
                             me->writeDataToFile(buffer, file);
                           }
-                          me->endDataReceiving();
+                          me->endDataReceiving(file);
                           return;
                         }
                         else if (length > 0)
@@ -1086,10 +1086,12 @@ namespace fineftp
                         });
   }
 
-  void FtpSession::endDataReceiving()
+  void FtpSession::endDataReceiving(std::shared_ptr<IoFile> file)
   {
-    file_rw_strand_.post([me = shared_from_this()]
+    file_rw_strand_.post([me = shared_from_this(), file]
                         {
+                          file->file_stream_.flush();
+                          file->file_stream_.close();
                           me->sendFtpMessage(FtpReplyCode::CLOSING_DATA_CONNECTION, "Done");
                         });
   }

--- a/fineftp-server/src/ftp_session.h
+++ b/fineftp-server/src/ftp_session.h
@@ -138,7 +138,7 @@ namespace fineftp
                        , std::shared_ptr<IoFile>            file
                        , std::function<void(void)>          fetch_more = []() {return; });
 
-    void endDataReceiving();
+    void endDataReceiving(std::shared_ptr<IoFile> file);
 
   ////////////////////////////////////////////////////////
   // Helpers


### PR DESCRIPTION
The Race condition could cause a file that was sent to the FTP Server not being flushed completely when the server returns "Done". This could cause immediate file operations to fail.