### PR TITLE
Add explicit <cstring> include to build with with GCC 12.

### DIFF
--- a/fineftp-server/src/filesystem.cpp
+++ b/fineftp-server/src/filesystem.cpp
@@ -14,6 +14,7 @@
 
 #else // WIN32
 
+#include <cstring>
 #include <dirent.h>
 
 #endif // WIN32


### PR DESCRIPTION
Hello,

adding this include makes fineftp build with GCC 12. As this is only making something explicit that was implicit before, it should not have any effects on older platforms and/or compilers.

Would it be possible to merge this?

cstring provides strerror().