### PR TITLE
Use mem mapped files when sending

### DIFF
--- a/fineftp-server/CMakeLists.txt
+++ b/fineftp-server/CMakeLists.txt
@@ -38,6 +38,13 @@ set(sources
     src/win_str_convert.h
 )
 
+if (WIN32)
+    list(APPEND sources src/win32/file_man.cpp)
+    set(platform_include src/win32)
+else()
+    list(APPEND sources src/unix/file_man.cpp)
+    set(platform_include src/unix)
+endif()
 
 add_library (${PROJECT_NAME}
     ${includes}
@@ -92,6 +99,7 @@ target_include_directories(${PROJECT_NAME}
     $<INSTALL_INTERFACE:include>
   PRIVATE
     src/
+    ${platform_include}
 )
 
 set_target_properties(${PROJECT_NAME} PROPERTIES

--- a/fineftp-server/src/filesystem.cpp
+++ b/fineftp-server/src/filesystem.cpp
@@ -8,7 +8,9 @@
 
 #ifdef WIN32
 
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <win_str_convert.h>

--- a/fineftp-server/src/unix/file_man.cpp
+++ b/fineftp-server/src/unix/file_man.cpp
@@ -1,0 +1,87 @@
+/// @file
+
+#include "file_man.h"
+
+#include <fcntl.h>
+#include <map>
+#include <mutex>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sstream>
+#include <unistd.h>
+
+namespace fineftp
+{
+
+namespace {
+
+std::mutex                                         guard;
+std::map<std::string, std::weak_ptr<ReadableFile>> files;
+
+}  // namespace
+
+ReadableFile::~ReadableFile()
+{
+  if (nullptr != data_)
+  {
+    ::munmap(data_, size_);
+  }
+
+  std::lock_guard<std::mutex> lock{guard};
+  if (!pth_.empty())
+  {
+    (void)files.erase(pth_);
+  }
+}
+
+std::shared_ptr<ReadableFile> ReadableFile::get(const std::string& pth)
+{
+  // Prevent use of relative paths as they are a security problem
+  if (pth.size() == 0 || pth[0] == '/' || std::string::npos != pth.find("../"))
+  {
+    return {};
+  }
+
+  // See if we already have this file mapped
+  std::lock_guard<std::mutex> lock{guard};
+  auto                        fit = files.find(pth);
+  if (files.end() != fit)
+  {
+    auto p = fit->second.lock();
+    if (p)
+    {
+      return p;
+    }
+  }
+  
+  auto handle = ::open(pth.c_str(), O_RDONLY);
+  if (-1 == handle)
+  {
+    return {};
+  }
+
+  struct stat st;
+  if (-1 == ::fstat(handle, &st))
+  {
+    ::close(handle);
+    return {};
+  }
+
+  auto map_start = ::mmap(0, st.st_size, PROT_READ, MAP_SHARED, handle, 0);
+  if (MAP_FAILED == map_start)
+  {
+    ::close(handle);
+    return {};
+  }
+
+  ::close(handle);
+
+  std::shared_ptr<ReadableFile> p{new ReadableFile{}};
+  p->pth_        = pth;
+  p->size_       = st.st_size;
+  p->data_       = static_cast<uint8_t*>(map_start);
+  files[p->pth_] = p;
+  return p;
+}
+
+}

--- a/fineftp-server/src/unix/file_man.h
+++ b/fineftp-server/src/unix/file_man.h
@@ -1,0 +1,73 @@
+/// @file
+
+#ifndef FINEFTP_SERVER_SRC_UNIX_FILE_MAN_H_
+#define FINEFTP_SERVER_SRC_UNIX_FILE_MAN_H_
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+namespace fineftp
+{
+
+/// A memory mapped read-only file.
+///
+/// @note The implementation is NOT thread safe!
+class ReadableFile
+{
+public:
+  ReadableFile(const ReadableFile&)            = delete;
+  ReadableFile& operator=(const ReadableFile&) = delete;
+  ReadableFile(ReadableFile&&)                 = delete;
+  ReadableFile& operator=(ReadableFile&&)      = delete;
+  ~ReadableFile();
+
+  /// Retrieves the file at the specified path.
+  ///
+  /// @param pth      The path of the file.
+  ///
+  /// @param The requested file or nullptr if the file could not be retrieved.
+  static std::shared_ptr<ReadableFile> get(const std::string& pth);
+
+  /// Returns the size of the file.
+  ///
+  /// @return The size of the file.
+  std::size_t size() const;
+
+  /// Returns a pointer to the beginning of the file contents.
+  ///
+  /// @return A pointer to the beginning of the file contents.
+  const std::uint8_t* data() const;
+
+  /// Returns the path of the file.
+  ///
+  /// @return The path of the file.
+  const std::string& path() const;
+
+private:
+  ReadableFile() = default;
+
+  std::string   pth_    = {};
+  std::size_t   size_   = {};
+  std::uint8_t* data_   = {};
+};
+
+inline std::size_t ReadableFile::size() const
+{
+  return size_;
+}
+
+inline const std::uint8_t* ReadableFile::data() const
+{
+  return data_;
+}
+   
+inline const std::string& ReadableFile::path() const
+{
+  return pth_;
+}
+
+}
+
+#endif  // FINEFTP_SERVER_SRC_UNIX_FILE_MAN_H_
+

--- a/fineftp-server/src/win32/file_man.cpp
+++ b/fineftp-server/src/win32/file_man.cpp
@@ -1,0 +1,109 @@
+/// @file
+
+#include "file_man.h"
+
+#include <map>
+#include <mutex>
+#include <sstream>
+
+namespace fineftp
+{
+
+namespace {
+
+std::mutex                                         guard;
+std::map<std::string, std::weak_ptr<ReadableFile>> files;
+
+}  // namespace
+
+ReadableFile::~ReadableFile()
+{
+  if (INVALID_HANDLE_VALUE != handle_)
+  {
+    ::UnmapViewOfFile(data_);
+    ::CloseHandle(map_handle_);
+    ::CloseHandle(handle_);
+  }
+
+  std::lock_guard<std::mutex> lock{guard};
+  if (!pth_.empty())
+  {
+    (void)files.erase(pth_);
+  }
+}
+
+std::shared_ptr<ReadableFile> ReadableFile::get(const std::string& pth)
+{
+  std::ostringstream os;
+  for (auto c : pth)
+  {
+    if (c == '/')
+    {
+      os << '\\';
+    }
+    else
+    {
+      os << c;
+    }
+  }
+
+  // Prevent use of relative paths as they are a security problem
+  auto&& s = os.str();
+  if (s.size() == 0 || s[0] == '/' || std::string::npos != s.find("../"))
+  {
+    return {};
+  }
+
+  // See if we already have this file mapped
+  std::lock_guard<std::mutex> lock{guard};
+  auto                        fit = files.find(s);
+  if (files.end() != fit)
+  {
+    auto p = fit->second.lock();
+    if (p)
+    {
+      return p;
+    }
+  }
+
+  auto handle =
+    ::CreateFileA(s.c_str(), GENERIC_READ, FILE_SHARE_READ, 0, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, 0);
+  if (INVALID_HANDLE_VALUE == handle)
+  {
+    return {};
+  }
+
+  LARGE_INTEGER sz;
+  if (0 == ::GetFileSizeEx(handle, &sz))
+  {
+    ::CloseHandle(handle);
+    return {};
+  }
+
+  auto map_handle = ::CreateFileMapping(handle, 0, PAGE_READONLY, sz.HighPart, sz.LowPart, 0);
+  if (INVALID_HANDLE_VALUE == map_handle)
+  {
+    ::CloseHandle(handle);
+    return {};
+  }
+
+  auto map_start = ::MapViewOfFile(map_handle, FILE_MAP_READ, 0, 0, sz.QuadPart);
+  if (nullptr == map_start)
+  {
+    ::CloseHandle(map_handle);
+    ::CloseHandle(handle);
+    return {};
+  }
+
+  std::shared_ptr<ReadableFile> p{new ReadableFile{}};
+  p->pth_        = std::move(s);
+  p->size_       = sz.QuadPart;
+  p->data_       = static_cast<uint8_t*>(map_start);
+  p->handle_     = handle;
+  p->map_handle_ = map_handle;
+  files[p->pth_] = p;
+  return p;
+}
+
+}
+

--- a/fineftp-server/src/win32/file_man.h
+++ b/fineftp-server/src/win32/file_man.h
@@ -1,0 +1,77 @@
+/// @file
+
+#ifndef FINEFTP_SERVER_SRC_WIN32_FILE_MAN_H_
+#define FINEFTP_SERVER_SRC_WIN32_FILE_MAN_H_
+
+#include <windows.h>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+namespace fineftp
+{
+
+/// A memory mapped read-only file.
+///
+/// @note The implementation is NOT thread safe!
+class ReadableFile
+{
+public:
+  ReadableFile(const ReadableFile&)            = delete;
+  ReadableFile& operator=(const ReadableFile&) = delete;
+  ReadableFile(ReadableFile&&)                 = delete;
+  ReadableFile& operator=(ReadableFile&&)      = delete;
+  ~ReadableFile();
+
+  /// Retrieves the file at the specified path.
+  ///
+  /// @param pth      The path of the file.
+  ///
+  /// @param The requested file or nullptr if the file could not be retrieved.
+  static std::shared_ptr<ReadableFile> get(const std::string& pth);
+
+  /// Returns the size of the file.
+  ///
+  /// @return The size of the file.
+  std::size_t size() const;
+
+  /// Returns a pointer to the beginning of the file contents.
+  ///
+  /// @return A pointer to the beginning of the file contents.
+  const std::uint8_t* data() const;
+
+  /// Returns the path of the file.
+  ///
+  /// @return The path of the file.
+  const std::string& path() const;
+
+private:
+  ReadableFile() = default;
+
+  std::string   pth_        = {};
+  std::size_t   size_       = {};
+  std::uint8_t* data_       = {};
+  HANDLE        handle_     = INVALID_HANDLE_VALUE;
+  HANDLE        map_handle_ = INVALID_HANDLE_VALUE;
+};
+
+inline std::size_t ReadableFile::size() const
+{
+  return size_;
+}
+
+inline const std::uint8_t* ReadableFile::data() const
+{
+  return data_;
+}
+
+inline const std::string& ReadableFile::path() const
+{
+  return pth_;
+}
+
+}
+
+#endif  // FINEFTP_SERVER_SRC_WIN32_FILE_MAN_H_
+

--- a/fineftp-server/src/win_str_convert.cpp
+++ b/fineftp-server/src/win_str_convert.cpp
@@ -2,7 +2,9 @@
 
 #ifdef WIN32
   #define WIN32_LEAN_AND_MEAN
-  #define NOMINMAX
+  #ifndef NOMINMAX
+    #define NOMINMAX
+  #endif
   #include <windows.h>
 #endif // WIN32
 


### PR DESCRIPTION
This change implies that files to be sent will be mapped into memory. This should speed up file transfer and reduce heap memory consumption.

Note that this also fixes a problem on Windows in relation to ASCII transfer: On Windows, even ASCII files should be transferred as binary files because the FTP spec state that such files should contain the carriage return and line feed characters at lined endings, and that just happens to be matching the binary encoding of Windows ASCII files.

On Unix, ASCII transfer will (still) be broken because the required translation from Unix line endings to Windows line endings is absent. But that's also a problem in the current master (prior to the present pull request).