### PR TITLE
Fix compile error (clang) and deprecation warning (gcc)

### DIFF
--- a/fineftp-server/src/ftp_session.cpp
+++ b/fineftp-server/src/ftp_session.cpp
@@ -6,6 +6,7 @@
 #include <map>
 #include <functional>
 #include <fstream>
+#include <sstream>
 
 
 #include "filesystem.h"

--- a/fineftp-server/src/server_impl.cpp
+++ b/fineftp-server/src/server_impl.cpp
@@ -88,16 +88,16 @@ namespace fineftp
 #endif // NDEBUG
 
     acceptor_.async_accept(ftp_session->getSocket()
-                          , [=](auto ec)
+                          , [this, ftp_session](auto ec)
                           {
                             open_connection_count_++;
 
-                            this->acceptFtpSession(ftp_session, ec);
+                            acceptFtpSession(ftp_session, ec);
                           });
 
     for (size_t i = 0; i < thread_count; i++)
     {
-      thread_pool_.emplace_back([=] {io_service_.run(); });
+      thread_pool_.emplace_back([this] {io_service_.run(); });
     }
     
     return true;
@@ -132,10 +132,10 @@ namespace fineftp
     auto new_session = std::make_shared<FtpSession>(io_service_, ftp_users_, [this]() { open_connection_count_--; });
 
     acceptor_.async_accept(new_session->getSocket()
-                          , [=](auto ec)
+                          , [this, new_session](auto ec)
                           {
                             open_connection_count_++;
-                            this->acceptFtpSession(new_session, ec);
+                            acceptFtpSession(new_session, ec);
                           });
   }
 


### PR DESCRIPTION
Building with apple-clang (14.0.3) and libc++ failed because of missing `<sstream>` include,
and GCC (13.1.1) has deprecated implicit capture of `this` using `[=]` since C++20.

I'm [packaging this library](https://github.com/build2-packaging/fineftp-server) for [`build2`](build2.org), and these fixes are required for it to be published. That said, if a `1.3.5` could be done once these are in, that'd be great!

Thanks.