### PR TITLE
Prevent PASV command from reporting signed numbers

### DIFF
--- a/fineftp-server/src/ftp_session.cpp
+++ b/fineftp-server/src/ftp_session.cpp
@@ -454,9 +454,9 @@ namespace fineftp
     // Form reply string
     std::stringstream stream;
     stream << "(";
-    for (const char byte : ip_bytes)
+    for (const auto byte : ip_bytes)
     {
-      stream << static_cast<int>(byte) << ",";
+      stream << static_cast<unsigned int>(byte) << ",";
     }
     stream << ((port >> 8) & 0xff) << "," << (port & 0xff) << ")";
 


### PR DESCRIPTION
A signed-unsigned conversion was making the
PASV command sometimes report signed numbers.
This was detected by the Windows firewall as
a problematice connection and it therefore
terminated the connection.