### PR TITLE
Bugfix/delay sending 226

### DIFF
--- a/fineftp-server/src/ftp_session.cpp
+++ b/fineftp-server/src/ftp_session.cpp
@@ -454,9 +454,9 @@ namespace fineftp
     // Form reply string
     std::stringstream stream;
     stream << "(";
-    for (const char byte : ip_bytes)
+    for (const auto byte : ip_bytes)
     {
-      stream << static_cast<int>(byte) << ",";
+      stream << static_cast<unsigned int>(byte) << ",";
     }
     stream << ((port >> 8) & 0xff) << "," << (port & 0xff) << ")";
 

--- a/fineftp-server/src/ftp_session.h
+++ b/fineftp-server/src/ftp_session.h
@@ -207,5 +207,7 @@ namespace fineftp
     asio::io_service::strand                       data_socket_strand_;
     std::weak_ptr<asio::ip::tcp::socket>           data_socket_weakptr_;
     std::deque<std::shared_ptr<std::vector<char>>> data_buffer_;
+
+    asio::steady_timer                             timer_;
   };
 }


### PR DESCRIPTION
This pull request is supposed to go on top of the bugfix/pasv_signedness pullrequest. The rationale for the present pull request is that an FTP client implementation (lwftp) has been observed to close the data connection as soon as it receives the 226 status code - even though it hasn't received all data, yet. To improve interoperability with such buggy clients, sending of the 226 status code is delayed a bit.