### PR TITLE
Feature/compile config delay sending 226

### DIFF
--- a/fineftp-server/CMakeLists.txt
+++ b/fineftp-server/CMakeLists.txt
@@ -92,6 +92,14 @@ target_compile_options(${PROJECT_NAME} PRIVATE
                            $<$<CXX_COMPILER_ID:MSVC>:
                                 /W4>)
 
+# The below is used to configure an optional delay when sending the 226 response code when a file has been fetched.
+# The background for this option is that an FTP client implementation has been observed to close the data connection
+# as soon as it receives the 226 status code - even though it hasn't received/ all data, yet. To improve
+# interoperability with such buggy clients, sending of the 226 status code can be delayed a bit. The delay is specified
+# in milliseconds. If the delay is 0, no delay is introduced.
+set(FINEFTP_SERVER_DELAY_226_RESP_MS 0 CACHE STRING
+    "An optional delay (in ms) for the 226 response when a file has been fetched. Used to improve interoperability with buggy clients.")
+target_compile_definitions(${PROJECT_NAME} PRIVATE DELAY_226_RESP_MS=${FINEFTP_SERVER_DELAY_226_RESP_MS})
 
 # Add own public include directory
 target_include_directories(${PROJECT_NAME}

--- a/fineftp-server/src/ftp_session.cpp
+++ b/fineftp-server/src/ftp_session.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cassert> // assert
 #include <cctype>  // std::iscntrl, toupper
+#include <chrono>
 #include <cstddef>
 #include <cstdio>
 #include <fstream>
@@ -47,6 +48,7 @@ namespace fineftp
     , ftp_working_directory_("/")
     , data_acceptor_        (io_service)
     , data_socket_strand_   (io_service)
+    , timer_                (io_service)
   {
   }
 
@@ -1302,7 +1304,31 @@ namespace fineftp
                                                         }
                                                         else
                                                         {
-                                                          me->sendFtpMessage(FtpReplyCode::CLOSING_DATA_CONNECTION, "Done");
+                                                          // Ugly work-around:
+                                                          // An FTP client implementation has been observed to close the data connection
+                                                          // as soon as it receives the 226 status code - even though it hasn't received
+                                                          // all data, yet. To improve interoperability with such buggy clients, sending
+                                                          // of the 226 status code can be delayed a bit. The delay is defined through a
+                                                          // preprocessor definition. If the delay is 0, no delay is introduced at all.
+                                                          #if (0 == DELAY_226_RESP_MS)
+                                                            me->sendFtpMessage(FtpReplyCode::CLOSING_DATA_CONNECTION, "Done");
+                                                          #else
+                                                            // Close Data Socket properly
+                                                            {
+                                                              asio::error_code ec;
+                                                              data_socket->shutdown(asio::socket_base::shutdown_both, ec);
+                                                              data_socket->close(ec);
+                                                            }
+
+                                                            me->timer_.expires_after(std::chrono::milliseconds{DELAY_226_RESP_MS});
+                                                            me->timer_.async_wait(me->data_socket_strand_.wrap([me](const asio::error_code& ec)
+                                                                                  {
+                                                                                    if (ec != asio::error::operation_aborted)
+                                                                                    {
+                                                                                      me->sendFtpMessage(FtpReplyCode::CLOSING_DATA_CONNECTION, "Done");
+                                                                                    }
+                                                                                  }));
+                                                          #endif
                                                         }
                                                       });
                                   }

--- a/fineftp-server/src/ftp_session.cpp
+++ b/fineftp-server/src/ftp_session.cpp
@@ -1304,6 +1304,13 @@ namespace fineftp
                                                         }
                                                         else
                                                         {
+                                                          // Close Data Socket properly
+                                                          {
+                                                            asio::error_code ec;
+                                                            data_socket->shutdown(asio::socket_base::shutdown_both, ec);
+                                                            data_socket->close(ec);
+                                                          }
+
                                                           // Ugly work-around:
                                                           // An FTP client implementation has been observed to close the data connection
                                                           // as soon as it receives the 226 status code - even though it hasn't received
@@ -1313,13 +1320,6 @@ namespace fineftp
                                                           #if (0 == DELAY_226_RESP_MS)
                                                             me->sendFtpMessage(FtpReplyCode::CLOSING_DATA_CONNECTION, "Done");
                                                           #else
-                                                            // Close Data Socket properly
-                                                            {
-                                                              asio::error_code ec;
-                                                              data_socket->shutdown(asio::socket_base::shutdown_both, ec);
-                                                              data_socket->close(ec);
-                                                            }
-
                                                             me->timer_.expires_after(std::chrono::milliseconds{DELAY_226_RESP_MS});
                                                             me->timer_.async_wait(me->data_socket_strand_.wrap([me](const asio::error_code& ec)
                                                                                   {

--- a/fineftp-server/src/ftp_session.cpp
+++ b/fineftp-server/src/ftp_session.cpp
@@ -1306,9 +1306,9 @@ namespace fineftp
                                                         {
                                                           // Close Data Socket properly
                                                           {
-                                                            asio::error_code ec;
-                                                            data_socket->shutdown(asio::socket_base::shutdown_both, ec);
-                                                            data_socket->close(ec);
+                                                            asio::error_code errc;
+                                                            data_socket->shutdown(asio::socket_base::shutdown_both, errc);
+                                                            data_socket->close(errc);
                                                           }
 
                                                           // Ugly work-around:

--- a/fineftp-server/src/ftp_session.cpp
+++ b/fineftp-server/src/ftp_session.cpp
@@ -454,9 +454,9 @@ namespace fineftp
     // Form reply string
     std::stringstream stream;
     stream << "(";
-    for (const char byte : ip_bytes)
+    for (const auto byte : ip_bytes)
     {
-      stream << static_cast<int>(byte) << ",";
+      stream << static_cast<unsigned int>(byte) << ",";
     }
     stream << ((port >> 8) & 0xff) << "," << (port & 0xff) << ")";
 

--- a/fineftp-server/src/ftp_session.h
+++ b/fineftp-server/src/ftp_session.h
@@ -207,5 +207,7 @@ namespace fineftp
     asio::io_service::strand                       data_socket_strand_;
     std::weak_ptr<asio::ip::tcp::socket>           data_socket_weakptr_;
     std::deque<std::shared_ptr<std::vector<char>>> data_buffer_;
+
+    asio::steady_timer                             timer_;
   };
 }


### PR DESCRIPTION
An FTP client implementation has been
observed to close the data connection
as soon as it receives the 226 status
code - even though it hasn't received
all data, yet. To improve interoper
with such buggy clients, sending of
the 226 status code can now be delayed
a bit. The optional delay is controlled
by means of preprocessor define that
can be set from the cmake command
line through a cmake cache variable.