### PR TITLE
Add ability to redirect all prints

### DIFF
--- a/fineftp-server/include/fineftp/server.h
+++ b/fineftp-server/include/fineftp/server.h
@@ -43,84 +43,62 @@ namespace fineftp
   public:
     /**
      * @brief Creates an FTP Server instance that will listen on the the given control port and accept connections from the given network interface.
-     *
-     * If no port is provided, the default FTP Port 21 is used. If you want to
-     * use that port, make sure that your application runs as root.
-     *
+     * 
+     * Instead of binding the server to a specific address, the server can
+     * listen on any interface by providing "0.0.0.0" as address.
+     * 
      * Instead of using a predefined port, the operating system can choose a
      * free port port. Use port=0, if that behaviour is desired. The chosen port
      * can be determined by with getPort().
-     *
+     * 
+     * This constructor will accept streams for info and error log output.
+     * 
+     * @param address: The address to accept incoming connections from. Use "0.0.0.0" to accept connections from any address.
+     * @param port: The port to start the FTP server on. Use 0 to let the operating system choose a free port. Use 21 for using the default FTP port.
+     * @param output: Stream for info log output. Defaults to std::cout if constructors without that options are used.
+     * @param error: Stream for error log output. Defaults to std::cerr if constructors without that options are used.
+     */
+    FINEFTP_EXPORT FtpServer(const std::string& address, uint16_t port, std::ostream& output, std::ostream& error);
+
+    /**
+     * @brief Creates an FTP Server instance that will listen on the the given control port and accept connections from the given network interface.
+     * 
+     * If no port is provided, the default FTP Port 21 is used. If you want to
+     * use that port, make sure that your application runs as root.
+     * 
+     * Instead of using a predefined port, the operating system can choose a
+     * free port port. Use port=0, if that behaviour is desired. The chosen port
+     * can be determined by with getPort().
+     * 
+     * Logs will be printed to std::cout and std::cerr. If you want to use a
+     * different output stream, use the other constructor.
+     * 
      * @param port: The port to start the FTP server on. Defaults to 21.
      * @param host: The host to accept incoming connections from.
      */
     FINEFTP_EXPORT FtpServer(const std::string& address, uint16_t port = 21);
 
     /**
-     * @brief Creates an FTP Server instance that will listen on the the given control port and accept connections from the given network interface.
-     *
-     * If no port is provided, the default FTP Port 21 is used. If you want to
-     * use that port, make sure that your application runs as root.
-     *
-     * Instead of using a predefined port, the operating system can choose a
-     * free port port. Use port=0, if that behaviour is desired. The chosen port
-     * can be determined by with getPort().
-     *
-     * @param address: The address to accept incoming connections from.
-     * @param port: The port to start the FTP server on.
-     * @param output: Normal output prints. Defaults to std::cout.
-     * @param error: Error output prints. Defaults to std::cerr.
-     */
-    FINEFTP_EXPORT FtpServer(const std::string& address, uint16_t port, std::ostream& output = std::cout, std::ostream& error = std::cerr);
-
-    /**
-     * @brief Creates an FTP Server instance that will listen on the the given control port and accept connections from the given network interface.
-     *
-     * If no port is provided, the default FTP Port 21 is used. If you want to
-     * use that port, make sure that your application runs as root.
-     *
-     * @param address: The address to accept incoming connections from.
-     * @param output: Normal output prints.
-     * @param error: Error output prints.
-     */
-    FINEFTP_EXPORT FtpServer(const std::string& address, std::ostream& output, std::ostream& error);
-
-    /**
      * @brief Creates an FTP Server instance that will listen on the the given control port.
-     *
+     * 
      * If no port is provided, the default FTP Port 21 is used. If you want to
      * use that port, make sure that your application runs as root.
-     *
+     * 
      * Instead of using a predefined port, the operating system can choose a
      * free port port. Use port=0, if that behaviour is desired. The chosen port
      * can be determined by with getPort().
-     *
+     * 
      * This constructor will create an FTP Server binding to IPv4 0.0.0.0 and
      * Thus accepting connections from any IPv4 address.
      * For security reasons it might be desirable to bind to a specific IP
      * address. Use FtpServer(const std::string&, uint16_t) for that purpose.
-     *
+     * 
+     * Logs will be printed to std::cout and std::cerr. If you want to use a
+     * different output stream, use the other constructor.
+     * 
      * @param port: The port to start the FTP server on. Defaults to 21.
      */
-    FINEFTP_EXPORT FtpServer(uint16_t port = 21);
-
-    /**
-     * @brief Creates an FTP Server instance that will listen on the the given control port.
-     *
-     * Instead of using a predefined port, the operating system can choose a
-     * free port port. Use port=0, if that behaviour is desired. The chosen port
-     * can be determined by with getPort().
-     *
-     * This constructor will create an FTP Server binding to IPv4 0.0.0.0 and
-     * Thus accepting connections from any IPv4 address.
-     * For security reasons it might be desirable to bind to a specific IP
-     * address. Use FtpServer(const std::string&, uint16_t) for that purpose.
-     *
-     * @param port: The port to start the FTP server on. Defaults to 21.
-     * @param output: Normal output prints. Defaults to std::cout.
-     * @param error: Error output prints. Defaults to std::cerr.
-     */
-    FINEFTP_EXPORT FtpServer(uint16_t port, std::ostream& output, std::ostream& error);
+    FINEFTP_EXPORT explicit FtpServer(uint16_t port = 21);
 
     // Move
     FINEFTP_EXPORT FtpServer(FtpServer&&) noexcept;
@@ -135,18 +113,18 @@ namespace fineftp
 
     /**
      * @brief Adds a new user
-     *
+     * 
      * Adds a new user with a given username, password, local root path and
      * permissions.
-     *
+     * 
      * Note that the username "anonymous" and "ftp" are reserved, as those are
      * well-known usernames usually used for accessing FTP servers without a
      * password. If adding a user with any of those usernames, the password will
      * be ignored, any user will be able to log in with any password!
-     *
+     * 
      * The Permissions are flags that are or-ed bit-wise and control what the
      * user will be able to do.
-     *
+     * 
      * @param username:         The username for login
      * @param password:         The user's password
      * @param local_root_path:  A path to any resource on the local filesystem that will be accessed by the user
@@ -158,26 +136,26 @@ namespace fineftp
 
     /**
      * @brief Adds the "anonymous" / "ftp" user that FTP clients use to access FTP servers without password
-     *
+     * 
      * @param local_root_path:  A path to any resource on the local filesystem that will be accessed by the user
      * @param permissions:      A bit-mask of what the user will be able to do.
-     *
+     * 
      * @return True if adding the anonymous user was successful (i.e. it didn't exit already).
      */
     FINEFTP_EXPORT bool addUserAnonymous(const std::string& local_root_path, Permission permissions);
 
     /**
      * @brief Starts the FTP Server
-     *
+     * 
      * @param thread_count: The size of the thread pool to use. Must not be 0.
-     *
+     * 
      * @return True if the Server has been started successfully.
      */
     FINEFTP_EXPORT bool start(size_t thread_count = 1);
 
     /**
      * @brief Stops the FTP Server
-     *
+     * 
      * All operations will be cancelled as fast as possible. The clients will
      * not be informed about the shutdown.
      */
@@ -185,26 +163,26 @@ namespace fineftp
 
     /**
      * @brief Returns the number of currently open connections
-     *
+     * 
      * @return the number of open connections
      */
     FINEFTP_EXPORT int getOpenConnectionCount() const;
 
     /**
      * @brief Get the control port that the FTP server is listening on
-     *
+     * 
      * When the server was created with a specific port (not 0), this port will
      * be returned.
      * If the server however was created with port 0, the operating system will
      * choose a free port. This method will return that port.
-     *
+     * 
      * @return The control port the server is listening on
      */
     FINEFTP_EXPORT uint16_t getPort() const;
 
     /**
      * @brief Get the ip address that the FTP server is listening for.
-     *
+     * 
      * @return The ip address the FTP server is listening for.
      */
     FINEFTP_EXPORT std::string getAddress() const;

--- a/fineftp-server/include/fineftp/server.h
+++ b/fineftp-server/include/fineftp/server.h
@@ -21,66 +21,92 @@ namespace fineftp
 
   /**
    * @brief The fineftp::FtpServer is a simple FTP server library.
-   * 
+   *
    * Using the FtpServer class is simple:
    *   1. Create an instance
    *   2. Add a user
    *   3. Start the server
-   * 
+   *
    * Then your server is up and running. In code it will look like this:
-   * 
+   *
    * @code{.cpp}
-   * 
+   *
    *   fineftp::FtpServer server(2121);
    *   server.addUserAnonymous("C:\\", fineftp::Permission::All);
    *   server.start();
-   * 
+   *
    * @endcode
-   * 
+   *
    */
   class FtpServer
   {
   public:
     /**
      * @brief Creates an FTP Server instance that will listen on the the given control port and accept connections from the given network interface.
-     * 
+     *
      * If no port is provided, the default FTP Port 21 is used. If you want to
      * use that port, make sure that your application runs as root.
-     * 
+     *
      * Instead of using a predefined port, the operating system can choose a
      * free port port. Use port=0, if that behaviour is desired. The chosen port
      * can be determined by with getPort().
-     * 
+     *
      * @param port: The port to start the FTP server on. Defaults to 21.
      * @param host: The host to accept incoming connections from.
-     * @param output: Normal output prints. Defaults to std::cout.
-     * @param error: Error output prints. Defaults to std::cerr.
      */
-    FINEFTP_EXPORT FtpServer(const std::string& address, uint16_t port = 21, std::ostream& output = std::cout, std::ostream& error = std::cerr);
+    FINEFTP_EXPORT FtpServer(const std::string& address, uint16_t port = 21);
 
     /**
      * @brief Creates an FTP Server instance that will listen on the the given control port and accept connections from the given network interface.
-     * 
+     *
      * If no port is provided, the default FTP Port 21 is used. If you want to
      * use that port, make sure that your application runs as root.
-     * 
+     *
      * Instead of using a predefined port, the operating system can choose a
      * free port port. Use port=0, if that behaviour is desired. The chosen port
      * can be determined by with getPort().
-     * 
-     * @param port: The port to start the FTP server on. Defaults to 21.
-     * @param host: The host to accept incoming connections from.
+     *
+     * @param address: The address to accept incoming connections from.
+     * @param port: The port to start the FTP server on.
      * @param output: Normal output prints. Defaults to std::cout.
      * @param error: Error output prints. Defaults to std::cerr.
      */
-    FINEFTP_EXPORT FtpServer(const std::string& address, std::ostream& output = std::cout, std::ostream& error = std::cerr);
+    FINEFTP_EXPORT FtpServer(const std::string& address, uint16_t port, std::ostream& output = std::cout, std::ostream& error = std::cerr);
+
+    /**
+     * @brief Creates an FTP Server instance that will listen on the the given control port and accept connections from the given network interface.
+     *
+     * If no port is provided, the default FTP Port 21 is used. If you want to
+     * use that port, make sure that your application runs as root.
+     *
+     * @param address: The address to accept incoming connections from.
+     * @param output: Normal output prints.
+     * @param error: Error output prints.
+     */
+    FINEFTP_EXPORT FtpServer(const std::string& address, std::ostream& output, std::ostream& error);
 
     /**
      * @brief Creates an FTP Server instance that will listen on the the given control port.
-     * 
+     *
      * If no port is provided, the default FTP Port 21 is used. If you want to
      * use that port, make sure that your application runs as root.
-     * 
+     *
+     * Instead of using a predefined port, the operating system can choose a
+     * free port port. Use port=0, if that behaviour is desired. The chosen port
+     * can be determined by with getPort().
+     *
+     * This constructor will create an FTP Server binding to IPv4 0.0.0.0 and
+     * Thus accepting connections from any IPv4 address.
+     * For security reasons it might be desirable to bind to a specific IP
+     * address. Use FtpServer(const std::string&, uint16_t) for that purpose.
+     *
+     * @param port: The port to start the FTP server on. Defaults to 21.
+     */
+    FINEFTP_EXPORT FtpServer(uint16_t port = 21);
+
+    /**
+     * @brief Creates an FTP Server instance that will listen on the the given control port.
+     *
      * Instead of using a predefined port, the operating system can choose a
      * free port port. Use port=0, if that behaviour is desired. The chosen port
      * can be determined by with getPort().
@@ -94,7 +120,7 @@ namespace fineftp
      * @param output: Normal output prints. Defaults to std::cout.
      * @param error: Error output prints. Defaults to std::cerr.
      */
-    FINEFTP_EXPORT FtpServer(uint16_t port = 21, std::ostream& output = std::cout, std::ostream& error = std::cerr);
+    FINEFTP_EXPORT FtpServer(uint16_t port, std::ostream& output, std::ostream& error);
 
     // Move
     FINEFTP_EXPORT FtpServer(FtpServer&&) noexcept;
@@ -109,49 +135,49 @@ namespace fineftp
 
     /**
      * @brief Adds a new user
-     * 
+     *
      * Adds a new user with a given username, password, local root path and
      * permissions.
-     * 
+     *
      * Note that the username "anonymous" and "ftp" are reserved, as those are
      * well-known usernames usually used for accessing FTP servers without a
      * password. If adding a user with any of those usernames, the password will
      * be ignored, any user will be able to log in with any password!
-     * 
+     *
      * The Permissions are flags that are or-ed bit-wise and control what the
      * user will be able to do.
-     * 
+     *
      * @param username:         The username for login
      * @param password:         The user's password
      * @param local_root_path:  A path to any resource on the local filesystem that will be accessed by the user
      * @param permissions:      A bit-mask of what the user will be able to do.
-     * 
+     *
      * @return True if adding the user was successful (i.e. it didn't exit already).
      */
     FINEFTP_EXPORT bool addUser(const std::string& username, const std::string& password, const std::string& local_root_path, Permission permissions);
-    
+
     /**
      * @brief Adds the "anonymous" / "ftp" user that FTP clients use to access FTP servers without password
-     * 
+     *
      * @param local_root_path:  A path to any resource on the local filesystem that will be accessed by the user
      * @param permissions:      A bit-mask of what the user will be able to do.
-     * 
+     *
      * @return True if adding the anonymous user was successful (i.e. it didn't exit already).
      */
     FINEFTP_EXPORT bool addUserAnonymous(const std::string& local_root_path, Permission permissions);
 
     /**
      * @brief Starts the FTP Server
-     * 
+     *
      * @param thread_count: The size of the thread pool to use. Must not be 0.
-     * 
+     *
      * @return True if the Server has been started successfully.
      */
     FINEFTP_EXPORT bool start(size_t thread_count = 1);
 
     /**
      * @brief Stops the FTP Server
-     * 
+     *
      * All operations will be cancelled as fast as possible. The clients will
      * not be informed about the shutdown.
      */
@@ -166,19 +192,19 @@ namespace fineftp
 
     /**
      * @brief Get the control port that the FTP server is listening on
-     * 
+     *
      * When the server was created with a specific port (not 0), this port will
      * be returned.
      * If the server however was created with port 0, the operating system will
      * choose a free port. This method will return that port.
-     * 
+     *
      * @return The control port the server is listening on
      */
     FINEFTP_EXPORT uint16_t getPort() const;
 
     /**
      * @brief Get the ip address that the FTP server is listening for.
-     * 
+     *
      * @return The ip address the FTP server is listening for.
      */
     FINEFTP_EXPORT std::string getAddress() const;

--- a/fineftp-server/include/fineftp/server.h
+++ b/fineftp-server/include/fineftp/server.h
@@ -21,22 +21,22 @@ namespace fineftp
 
   /**
    * @brief The fineftp::FtpServer is a simple FTP server library.
-   *
+   * 
    * Using the FtpServer class is simple:
    *   1. Create an instance
    *   2. Add a user
    *   3. Start the server
-   *
+   * 
    * Then your server is up and running. In code it will look like this:
-   *
+   * 
    * @code{.cpp}
-   *
+   * 
    *   fineftp::FtpServer server(2121);
    *   server.addUserAnonymous("C:\\", fineftp::Permission::All);
    *   server.start();
-   *
+   * 
    * @endcode
-   *
+   * 
    */
   class FtpServer
   {

--- a/fineftp-server/include/fineftp/server.h
+++ b/fineftp-server/include/fineftp/server.h
@@ -59,6 +59,23 @@ namespace fineftp
     FINEFTP_EXPORT FtpServer(const std::string& address, const uint16_t port = 21, std::ostream& output = std::cout, std::ostream& error = std::cerr);
 
     /**
+     * @brief Creates an FTP Server instance that will listen on the the given control port and accept connections from the given network interface.
+     * 
+     * If no port is provided, the default FTP Port 21 is used. If you want to
+     * use that port, make sure that your application runs as root.
+     * 
+     * Instead of using a predefined port, the operating system can choose a
+     * free port port. Use port=0, if that behaviour is desired. The chosen port
+     * can be determined by with getPort().
+     * 
+     * @param port: The port to start the FTP server on. Defaults to 21.
+     * @param host: The host to accept incoming connections from.
+     * @param output: Normal output prints. Defaults to std::cout.
+     * @param error: Error output prints. Defaults to std::cerr.
+     */
+    FINEFTP_EXPORT FtpServer(const std::string& address, std::ostream& output = std::cout, std::ostream& error = std::cerr);
+
+    /**
      * @brief Creates an FTP Server instance that will listen on the the given control port.
      * 
      * If no port is provided, the default FTP Port 21 is used. If you want to

--- a/fineftp-server/include/fineftp/server.h
+++ b/fineftp-server/include/fineftp/server.h
@@ -56,7 +56,7 @@ namespace fineftp
      * @param output: Normal output prints. Defaults to std::cout.
      * @param error: Error output prints. Defaults to std::cerr.
      */
-    FINEFTP_EXPORT FtpServer(const std::string& address, const uint16_t port = 21, std::ostream& output = std::cout, std::ostream& error = std::cerr);
+    FINEFTP_EXPORT FtpServer(const std::string& address, uint16_t port = 21, std::ostream& output = std::cout, std::ostream& error = std::cerr);
 
     /**
      * @brief Creates an FTP Server instance that will listen on the the given control port and accept connections from the given network interface.
@@ -94,7 +94,7 @@ namespace fineftp
      * @param output: Normal output prints. Defaults to std::cout.
      * @param error: Error output prints. Defaults to std::cerr.
      */
-    FINEFTP_EXPORT FtpServer(const uint16_t port = 21, std::ostream& output = std::cout, std::ostream& error = std::cerr);
+    FINEFTP_EXPORT FtpServer(uint16_t port = 21, std::ostream& output = std::cout, std::ostream& error = std::cerr);
 
     // Move
     FINEFTP_EXPORT FtpServer(FtpServer&&) noexcept;

--- a/fineftp-server/include/fineftp/server.h
+++ b/fineftp-server/include/fineftp/server.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <iostream>
 
 // IWYU pragma: begin_exports
 #include <fineftp/permissions.h>
@@ -52,8 +53,10 @@ namespace fineftp
      * 
      * @param port: The port to start the FTP server on. Defaults to 21.
      * @param host: The host to accept incoming connections from.
+     * @param output: Normal output prints. Defaults to std::cout.
+     * @param error: Error output prints. Defaults to std::cerr.
      */
-    FINEFTP_EXPORT FtpServer(const std::string& address, uint16_t port = 21);
+    FINEFTP_EXPORT FtpServer(const std::string& address, const uint16_t port = 21, std::ostream& output = std::cout, std::ostream& error = std::cerr);
 
     /**
      * @brief Creates an FTP Server instance that will listen on the the given control port.
@@ -71,8 +74,10 @@ namespace fineftp
      * address. Use FtpServer(const std::string&, uint16_t) for that purpose.
      *
      * @param port: The port to start the FTP server on. Defaults to 21.
+     * @param output: Normal output prints. Defaults to std::cout.
+     * @param error: Error output prints. Defaults to std::cerr.
      */
-    FINEFTP_EXPORT FtpServer(uint16_t port = 21);
+    FINEFTP_EXPORT FtpServer(const uint16_t port = 21, std::ostream& output = std::cout, std::ostream& error = std::cerr);
 
     // Move
     FINEFTP_EXPORT FtpServer(FtpServer&&) noexcept;

--- a/fineftp-server/src/filesystem.cpp
+++ b/fineftp-server/src/filesystem.cpp
@@ -283,7 +283,7 @@ namespace Filesystem
     return can_open_dir;
   }
 
-  std::map<std::string, FileStatus> dirContent(const std::string& path)
+  std::map<std::string, FileStatus> dirContent(const std::string& path, std::ostream& error)
   {
     std::map<std::string, FileStatus> content;
 #ifdef WIN32

--- a/fineftp-server/src/filesystem.cpp
+++ b/fineftp-server/src/filesystem.cpp
@@ -297,7 +297,7 @@ namespace Filesystem
     hFind = FindFirstFileW(w_find_file_path.c_str(), &ffd);
     if (hFind == INVALID_HANDLE_VALUE)
     {
-      error_ << "FindFirstFile Error" << std::endl;
+      error << "FindFirstFile Error" << std::endl;
       return content;
     }
 

--- a/fineftp-server/src/filesystem.cpp
+++ b/fineftp-server/src/filesystem.cpp
@@ -297,7 +297,7 @@ namespace Filesystem
     hFind = FindFirstFileW(w_find_file_path.c_str(), &ffd);
     if (hFind == INVALID_HANDLE_VALUE)
     {
-      std::cerr << "FindFirstFile Error" << std::endl;
+      error_ << "FindFirstFile Error" << std::endl;
       return content;
     }
 
@@ -312,7 +312,7 @@ namespace Filesystem
     struct dirent *dirp = nullptr;
     if(dp == nullptr)
     {
-        std::cerr << "Error opening directory: " << strerror(errno) << std::endl;
+        error << "Error opening directory: " << strerror(errno) << std::endl;
         return content;
     }
 

--- a/fineftp-server/src/filesystem.h
+++ b/fineftp-server/src/filesystem.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <map>
 #include <string>
+#include <iostream>
 
 #include <sys/stat.h>
 
@@ -68,7 +69,7 @@ namespace fineftp
   #endif 
     };
 
-    std::map<std::string, FileStatus> dirContent(const std::string& path);
+    std::map<std::string, FileStatus> dirContent(const std::string& path, std::ostream& error);
 
     std::string cleanPath(const std::string& path, bool path_is_windows_path, char output_separator);
 

--- a/fineftp-server/src/ftp_session.cpp
+++ b/fineftp-server/src/ftp_session.cpp
@@ -1,9 +1,11 @@
 #include "ftp_session.h"
 
+#include <asio.hpp>
+
 #include <algorithm>
 #include <cassert> // assert
 #include <cctype>  // std::iscntrl, toupper
-#include <chrono>
+#include <chrono>   // IWYU pragma: keep (it is used for special preprocessor defines)
 #include <cstddef>
 #include <cstdio>
 #include <fstream>
@@ -28,6 +30,11 @@
 #include <sys/stat.h>
 
 #ifdef WIN32
+  #define WIN32_LEAN_AND_MEAN
+  #ifndef NOMINMAX
+    #define NOMINMAX
+  #endif
+  #include <windows.h>
   #include "win_str_convert.h"
 #else
   #include <unistd.h>

--- a/fineftp-server/src/ftp_session.cpp
+++ b/fineftp-server/src/ftp_session.cpp
@@ -37,7 +37,7 @@
 namespace fineftp
 {
 
-  FtpSession::FtpSession(asio::io_service& io_service, const UserDatabase& user_database, const std::function<void()>& completion_handler)
+  FtpSession::FtpSession(asio::io_service& io_service, const UserDatabase& user_database, const std::function<void()>& completion_handler, std::ostream& output, std::ostream& error)
     : completion_handler_   (completion_handler)
     , user_database_        (user_database)
     , io_service_           (io_service)
@@ -49,6 +49,8 @@ namespace fineftp
     , data_acceptor_        (io_service)
     , data_socket_strand_   (io_service)
     , timer_                (io_service)
+    , output_(output)
+    , error_(error)
   {
   }
 
@@ -1060,7 +1062,7 @@ namespace fineftp
         if (dir_status.canOpenDir())
         {
           sendFtpMessage(FtpReplyCode::FILE_STATUS_OK_OPENING_DATA_CONNECTION, "Sending directory listing");
-          sendDirectoryListing(Filesystem::dirContent(local_path));
+          sendDirectoryListing(Filesystem::dirContent(local_path, error_));
           return;
         }
         else
@@ -1108,7 +1110,7 @@ namespace fineftp
         if (dir_status.canOpenDir())
         {
           sendFtpMessage(FtpReplyCode::FILE_STATUS_OK_OPENING_DATA_CONNECTION, "Sending name list");
-          sendNameList(Filesystem::dirContent(local_path));
+          sendNameList(Filesystem::dirContent(local_path, error_));
           return;
         }
         else

--- a/fineftp-server/src/ftp_session.h
+++ b/fineftp-server/src/ftp_session.h
@@ -33,7 +33,7 @@ namespace fineftp
   // Public API
   ////////////////////////////////////////////////////////
   public:
-    FtpSession(asio::io_service& io_service, const UserDatabase& user_database, const std::function<void()>& completion_handler);
+    FtpSession(asio::io_service& io_service, const UserDatabase& user_database, const std::function<void()>& completion_handler, std::ostream& output, std::ostream& error);
 
     // Copy (disabled, as we are inheriting from shared_from_this)
     FtpSession(const FtpSession&)            = delete;
@@ -209,5 +209,8 @@ namespace fineftp
     std::deque<std::shared_ptr<std::vector<char>>> data_buffer_;
 
     asio::steady_timer                             timer_;
+
+    std::ostream& output_;  /* Normal output log */
+    std::ostream& error_;   /* Error output log */
   };
 }

--- a/fineftp-server/src/server.cpp
+++ b/fineftp-server/src/server.cpp
@@ -12,12 +12,20 @@
 
 namespace fineftp
 {
+  FtpServer::FtpServer(const std::string& address, const uint16_t port)
+    : ftp_server_(std::make_unique<FtpServerImpl>(address, port, std::cout, std::cerr))
+  {}
+
   FtpServer::FtpServer(const std::string& address, const uint16_t port, std::ostream& output, std::ostream& error)
     : ftp_server_(std::make_unique<FtpServerImpl>(address, port, output, error))
   {}
 
   FtpServer::FtpServer(const std::string& address, std::ostream& output, std::ostream& error)
     : ftp_server_(std::make_unique<FtpServerImpl>(address, 21, output, error))
+  {}
+
+  FtpServer::FtpServer(const uint16_t port)
+    : FtpServer(std::string("0.0.0.0"), port, std::cout, std::cerr)
   {}
 
   FtpServer::FtpServer(const uint16_t port, std::ostream& output, std::ostream& error)

--- a/fineftp-server/src/server.cpp
+++ b/fineftp-server/src/server.cpp
@@ -2,34 +2,27 @@
 
 #include "server_impl.h"
 
-#include <memory>
-#include <string>
-#include <cstdint> // uint16_t
-#include <cstddef> // size_t
 #include <cassert> // assert
+#include <cstddef> // size_t
+#include <cstdint> // uint16_t
+#include <memory>
+#include <ostream>
+#include <string>
 
 #include <fineftp/permissions.h>
 
 namespace fineftp
 {
-  FtpServer::FtpServer(const std::string& address, const uint16_t port)
-    : ftp_server_(std::make_unique<FtpServerImpl>(address, port, std::cout, std::cerr))
-  {}
-
   FtpServer::FtpServer(const std::string& address, const uint16_t port, std::ostream& output, std::ostream& error)
     : ftp_server_(std::make_unique<FtpServerImpl>(address, port, output, error))
   {}
 
-  FtpServer::FtpServer(const std::string& address, std::ostream& output, std::ostream& error)
-    : ftp_server_(std::make_unique<FtpServerImpl>(address, 21, output, error))
+  FtpServer::FtpServer(const std::string& address, const uint16_t port)
+    : FtpServer(address, port, std::cout, std::cerr)
   {}
 
   FtpServer::FtpServer(const uint16_t port)
     : FtpServer(std::string("0.0.0.0"), port, std::cout, std::cerr)
-  {}
-
-  FtpServer::FtpServer(const uint16_t port, std::ostream& output, std::ostream& error)
-    : FtpServer(std::string("0.0.0.0"), port, output, error)
   {}
 
   // Move

--- a/fineftp-server/src/server.cpp
+++ b/fineftp-server/src/server.cpp
@@ -12,12 +12,12 @@
 
 namespace fineftp
 {
-  FtpServer::FtpServer(const std::string& address, uint16_t port)
-    : ftp_server_(std::make_unique<FtpServerImpl>(address, port))
+  FtpServer::FtpServer(const std::string& address, const uint16_t port, std::ostream& output, std::ostream& error)
+    : ftp_server_(std::make_unique<FtpServerImpl>(address, port, output, error))
   {}
 
-  FtpServer::FtpServer(uint16_t port)
-    : FtpServer(std::string("0.0.0.0"), port)
+  FtpServer::FtpServer(const uint16_t port, std::ostream& output, std::ostream& error)
+    : FtpServer(std::string("0.0.0.0"), port, output, error)
   {}
 
   // Move

--- a/fineftp-server/src/server.cpp
+++ b/fineftp-server/src/server.cpp
@@ -16,6 +16,10 @@ namespace fineftp
     : ftp_server_(std::make_unique<FtpServerImpl>(address, port, output, error))
   {}
 
+  FtpServer::FtpServer(const std::string& address, std::ostream& output, std::ostream& error)
+    : ftp_server_(std::make_unique<FtpServerImpl>(address, 21, output, error))
+  {}
+
   FtpServer::FtpServer(const uint16_t port, std::ostream& output, std::ostream& error)
     : FtpServer(std::string("0.0.0.0"), port, output, error)
   {}

--- a/fineftp-server/src/server_impl.cpp
+++ b/fineftp-server/src/server_impl.cpp
@@ -17,13 +17,13 @@ namespace fineftp
 {
 
   FtpServerImpl::FtpServerImpl(const std::string& address, const uint16_t port, std::ostream& output, std::ostream& error)
-    : ftp_users_(output, error)
+    : ftp_users_            (output, error)
     , port_                 (port)
     , address_              (address)
     , acceptor_             (io_service_)
     , open_connection_count_(0)
-    , output_(output)
-    , error_(error)
+    , output_               (output)
+    , error_                (error)
   {}
 
   FtpServerImpl::~FtpServerImpl()

--- a/fineftp-server/src/server_impl.cpp
+++ b/fineftp-server/src/server_impl.cpp
@@ -50,7 +50,7 @@ namespace fineftp
     const asio::ip::tcp::endpoint endpoint(asio::ip::make_address(address_, make_address_ec), port_);
     if (make_address_ec)
     {
-      std::cerr << "Error creating address from string \"" << address_<< "\": " << make_address_ec.message() << std::endl;
+      error_ << "Error creating address from string \"" << address_<< "\": " << make_address_ec.message() << std::endl;
       return false;
     }
     
@@ -59,7 +59,7 @@ namespace fineftp
       acceptor_.open(endpoint.protocol(), ec);
       if (ec)
       {
-        std::cerr << "Error opening acceptor: " << ec.message() << std::endl;
+        error_ << "Error opening acceptor: " << ec.message() << std::endl;
         return false;
       }
     }
@@ -69,7 +69,7 @@ namespace fineftp
       acceptor_.set_option(asio::ip::tcp::acceptor::reuse_address(true), ec);
       if (ec)
       {
-        std::cerr << "Error setting reuse_address option: " << ec.message() << std::endl;
+        error_ << "Error setting reuse_address option: " << ec.message() << std::endl;
         return false;
       }
     }
@@ -79,7 +79,7 @@ namespace fineftp
       acceptor_.bind(endpoint, ec);
       if (ec)
       {
-        std::cerr << "Error binding acceptor: " << ec.message() << std::endl;
+        error_ << "Error binding acceptor: " << ec.message() << std::endl;
         return false;
       }
     }
@@ -89,13 +89,13 @@ namespace fineftp
       acceptor_.listen(asio::socket_base::max_listen_connections, ec);
       if (ec)
       {
-        std::cerr << "Error listening on acceptor: " << ec.message() << std::endl;
+        error_ << "Error listening on acceptor: " << ec.message() << std::endl;
         return false;
       }
     }
     
 #ifndef NDEBUG
-    std::cout << "FTP Server created." << std::endl << "Listening at address " << acceptor_.local_endpoint().address() << " on port " << acceptor_.local_endpoint().port() << ":" << std::endl;
+    output_ << "FTP Server created." << std::endl << "Listening at address " << acceptor_.local_endpoint().address() << " on port " << acceptor_.local_endpoint().port() << ":" << std::endl;
 #endif // NDEBUG
 
     acceptor_.async_accept(ftp_session->getSocket()
@@ -129,13 +129,13 @@ namespace fineftp
     if (error)
     {
 #ifndef NDEBUG
-      std::cerr << "Error handling connection: " << error.message() << std::endl;
+      error_ << "Error handling connection: " << error.message() << std::endl;
 #endif
       return;
     }
 
 #ifndef NDEBUG
-    std::cout << "FTP Client connected: " << ftp_session->getSocket().remote_endpoint().address().to_string() << ":" << ftp_session->getSocket().remote_endpoint().port() << std::endl;
+    output_ << "FTP Client connected: " << ftp_session->getSocket().remote_endpoint().address().to_string() << ":" << ftp_session->getSocket().remote_endpoint().port() << std::endl;
 #endif
 
     ftp_session->start();

--- a/fineftp-server/src/server_impl.h
+++ b/fineftp-server/src/server_impl.h
@@ -20,7 +20,7 @@ namespace fineftp
   class FtpServerImpl
   {
   public:
-    FtpServerImpl(const std::string& address, const uint16_t port, std::ostream& output, std::ostream& error);
+    FtpServerImpl(const std::string& address, uint16_t port, std::ostream& output, std::ostream& error);
 
     // Copy (disabled)
     FtpServerImpl(const FtpServerImpl&)            = delete;

--- a/fineftp-server/src/server_impl.h
+++ b/fineftp-server/src/server_impl.h
@@ -20,7 +20,7 @@ namespace fineftp
   class FtpServerImpl
   {
   public:
-    FtpServerImpl(const std::string& address, uint16_t port);
+    FtpServerImpl(const std::string& address, const uint16_t port, std::ostream& output, std::ostream& error);
 
     // Copy (disabled)
     FtpServerImpl(const FtpServerImpl&)            = delete;
@@ -59,5 +59,8 @@ namespace fineftp
     asio::ip::tcp::acceptor  acceptor_;
 
     std::atomic<int> open_connection_count_;
+
+    std::ostream& output_;  /* Normal output log */
+    std::ostream& error_;   /* Error output log */
   };
 }

--- a/fineftp-server/src/user_database.cpp
+++ b/fineftp-server/src/user_database.cpp
@@ -14,7 +14,11 @@ namespace fineftp
   UserDatabase::UserDatabase(std::ostream& output, std::ostream& error)
     : output_(output)
     , error_(error)
-  { 
+  {
+#ifdef NDEBUG
+      // Avoid unused-private-field warning
+      static_cast<void>(output_);
+#endif // NDEBUG
   }
 
   bool UserDatabase::addUser(const std::string& username, const std::string& password, const std::string& local_root_path, Permission permissions)

--- a/fineftp-server/src/user_database.cpp
+++ b/fineftp-server/src/user_database.cpp
@@ -11,6 +11,12 @@
 
 namespace fineftp
 {
+  UserDatabase::UserDatabase(std::ostream& output, std::ostream& error)
+    : output_(output)
+    , error_(error)
+  { 
+  }
+
   bool UserDatabase::addUser(const std::string& username, const std::string& password, const std::string& local_root_path, Permission permissions)
   {
     const std::lock_guard<decltype(database_mutex_)> database_lock(database_mutex_);

--- a/fineftp-server/src/user_database.cpp
+++ b/fineftp-server/src/user_database.cpp
@@ -25,14 +25,14 @@ namespace fineftp
     {
       if (anonymous_user_)
       {
-        std::cerr << "Error adding user with username \"" << username << "\". The username denotes the anonymous user, which is already present." << std::endl;
+        error_ << "Error adding user with username \"" << username << "\". The username denotes the anonymous user, which is already present." << std::endl;
         return false;
       }
       else
       {
         anonymous_user_ = std::make_shared<FtpUser>(password, local_root_path, permissions);
 #ifndef NDEBUG
-        std::cout << "Successfully added anonymous user." << std::endl;
+        output_ << "Successfully added anonymous user." << std::endl;
 #endif // !NDEBUG
         return true;
       }
@@ -44,13 +44,13 @@ namespace fineftp
       {
         database_.emplace(username, std::make_shared<FtpUser>(password, local_root_path, permissions));
 #ifndef NDEBUG
-        std::cout << "Successfully added user \"" << username << "\"." << std::endl;
+        output_ << "Successfully added user \"" << username << "\"." << std::endl;
 #endif // !NDEBUG
         return true;
       }
       else
       {
-        std::cerr << "Error adding user with username \"" << username << "\". The user already exists." << std::endl;
+        error_ << "Error adding user with username \"" << username << "\". The user already exists." << std::endl;
         return false;
       }
     }

--- a/fineftp-server/src/user_database.h
+++ b/fineftp-server/src/user_database.h
@@ -13,6 +13,8 @@ namespace fineftp
   class UserDatabase
   {
   public:
+    UserDatabase(std::ostream& output, std::ostream& error);
+
     bool addUser(const std::string& username, const std::string& password, const std::string& local_root_path, Permission permissions);
 
     std::shared_ptr<FtpUser> getUser(const std::string& username, const std::string& password) const;
@@ -23,5 +25,8 @@ namespace fineftp
     mutable std::mutex                              database_mutex_;
     std::map<std::string, std::shared_ptr<FtpUser>> database_;
     std::shared_ptr<FtpUser>                        anonymous_user_;
+
+    std::ostream& output_;  /* Normal output log */
+    std::ostream& error_;   /* Error output log */
   };
 }

--- a/fineftp-server/src/win32/file_man.cpp
+++ b/fineftp-server/src/win32/file_man.cpp
@@ -2,9 +2,20 @@
 
 #include "file_man.h"
 
+#include <cstdint>
+#include <ios>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <sstream>
+#include <string>
+#include <utility>
+
+#define WIN32_LEAN_AND_MEAN
+#ifndef NOMINMAX
+  #define NOMINMAX
+#endif
+#include <windows.h>
 
 #include "win_str_convert.h"
 


### PR DESCRIPTION
Added `output` (which defaults to `std::cout`) and `error` (which defaults to `std::cerr`) to allow easier redirect of all prints.

Useful when used in a daemon for example or when using a more complex system like [spdlog](https://github.com/gabime/spdlog)