### PR TITLE
[cmake] Update supported policies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
-cmake_minimum_required(VERSION 3.5.1)
+# CMake 3.13 required by GTest
+cmake_minimum_required(VERSION 3.13)
 
 include(CMakeDependentOption)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # CMake 3.13 required by GTest
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.13...4.0)
 
 include(CMakeDependentOption)
 

--- a/fineftp-server/CMakeLists.txt
+++ b/fineftp-server/CMakeLists.txt
@@ -1,5 +1,5 @@
 # CMake 3.8 required for cxx_std_14
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.8...4.0)
 
 include("${CMAKE_CURRENT_LIST_DIR}/version.cmake")
 project(server VERSION ${FINEFTP_SERVER_VERSION_MAJOR}.${FINEFTP_SERVER_VERSION_MINOR}.${FINEFTP_SERVER_VERSION_PATCH})

--- a/fineftp-server/CMakeLists.txt
+++ b/fineftp-server/CMakeLists.txt
@@ -1,4 +1,5 @@
-cmake_minimum_required(VERSION 3.5.1)
+# CMake 3.8 required for cxx_std_14
+cmake_minimum_required(VERSION 3.8)
 
 include("${CMAKE_CURRENT_LIST_DIR}/version.cmake")
 project(server VERSION ${FINEFTP_SERVER_VERSION_MAJOR}.${FINEFTP_SERVER_VERSION_MINOR}.${FINEFTP_SERVER_VERSION_PATCH})

--- a/samples/fineftp_example/CMakeLists.txt
+++ b/samples/fineftp_example/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.5.1...4.0)
 
 project(fineftp_example)
 

--- a/samples/integration_test/CMakeLists.txt
+++ b/samples/integration_test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.5.1...4.0)
 
 project(integration_test)
 


### PR DESCRIPTION
Updates the project to support all policy changes up to CMake 4.0.

Corrected the hard version requirements.

There were no additional changes required.