### PR TITLE
Replaced WIN32 by _WIN32

### DIFF
--- a/fineftp-server/src/filesystem.h
+++ b/fineftp-server/src/filesystem.h
@@ -62,9 +62,9 @@ namespace fineftp
     private:
       std::string path_;
       bool is_ok_;
-  #ifdef WIN32
+  #ifdef _WIN32
       struct __stat64 file_status_;
-  #else // WIN32
+  #else // _WIN32
       struct stat file_status_;
   #endif 
     };

--- a/fineftp-server/src/ftp_session.cpp
+++ b/fineftp-server/src/ftp_session.cpp
@@ -29,7 +29,7 @@
 
 #include <sys/stat.h>
 
-#ifdef WIN32
+#ifdef _WIN32
   #define WIN32_LEAN_AND_MEAN
   #ifndef NOMINMAX
     #define NOMINMAX
@@ -38,7 +38,7 @@
   #include "win_str_convert.h"
 #else
   #include <unistd.h>
-#endif // WIN32
+#endif // _WIN32
 
 
 namespace fineftp
@@ -535,7 +535,7 @@ namespace fineftp
 
     const std::string local_path = toLocalPath(param);
     
-#if defined(WIN32) && !defined(__GNUG__)
+#if defined(_WIN32) && !defined(__GNUG__)
     const auto file = ReadableFile::get(StrConvert::Utf8ToWide(local_path));
 #else
     const auto file = ReadableFile::get(local_path);
@@ -572,7 +572,7 @@ namespace fineftp
        std::ios::ate | (data_type_binary_ ? (std::ios::in | std::ios::binary) : (std::ios::in));
     std::fstream::pos_type file_size;
     {
-#if defined(WIN32) && !defined(__GNUG__)
+#if defined(_WIN32) && !defined(__GNUG__)
       std::ifstream file(StrConvert::Utf8ToWide(local_path), open_mode);
 #else
       std::ifstream file(local_path, open_mode);
@@ -648,11 +648,11 @@ namespace fineftp
 
     if (!file->good())
     {
-#ifdef WIN32
+#ifdef _WIN32
       sendFtpMessage(FtpReplyCode::ACTION_ABORTED_LOCAL_ERROR, "Error opening file for transfer: " + GetLastErrorStr());
 #else
       sendFtpMessage(FtpReplyCode::ACTION_ABORTED_LOCAL_ERROR, "Error opening file for transfer");
-#endif // WIN32
+#endif // _WIN32
 
       return;
     }
@@ -721,11 +721,11 @@ namespace fineftp
 
     if (!file->good())
     {
-#ifdef WIN32
+#ifdef _WIN32
       sendFtpMessage(FtpReplyCode::ACTION_ABORTED_LOCAL_ERROR, "Error opening file for transfer: " + GetLastErrorStr());
 #else
       sendFtpMessage(FtpReplyCode::ACTION_ABORTED_LOCAL_ERROR, "Error opening file for transfer");
-#endif // WIN32
+#endif // _WIN32
       return;
     }
 
@@ -803,7 +803,7 @@ namespace fineftp
         return;
       }
 
-#ifdef WIN32
+#ifdef _WIN32
 
       if (MoveFileW(StrConvert::Utf8ToWide(local_from_path).c_str(), StrConvert::Utf8ToWide(local_to_path).c_str()) != 0)
       {
@@ -815,7 +815,7 @@ namespace fineftp
         sendFtpMessage(FtpReplyCode::FILE_ACTION_NOT_TAKEN, "Error renaming file: " + GetLastErrorStr());
         return;
       }
-#else // WIN32
+#else // _WIN32
       if (rename(local_from_path.c_str(), local_to_path.c_str()) == 0)
       {
         sendFtpMessage(FtpReplyCode::FILE_ACTION_COMPLETED, "OK");
@@ -826,7 +826,7 @@ namespace fineftp
         sendFtpMessage(FtpReplyCode::FILE_ACTION_NOT_TAKEN, "Error renaming file");
         return;
       }
-#endif // WIN32
+#endif // _WIN32
     }
     else
     {
@@ -870,7 +870,7 @@ namespace fineftp
       }
       else
       {
-#ifdef WIN32
+#ifdef _WIN32
         if (DeleteFileW(StrConvert::Utf8ToWide(local_path).c_str()) != 0)
         {
           sendFtpMessage(FtpReplyCode::FILE_ACTION_COMPLETED, "Successfully deleted file");
@@ -912,7 +912,7 @@ namespace fineftp
 
     const std::string local_path = toLocalPath(param);
 
-#ifdef WIN32
+#ifdef _WIN32
     if (RemoveDirectoryW(StrConvert::Utf8ToWide(local_path).c_str()) != 0)
     {
       sendFtpMessage(FtpReplyCode::FILE_ACTION_COMPLETED, "Successfully removed directory");
@@ -959,7 +959,7 @@ namespace fineftp
 
     auto local_path = toLocalPath(param);
 
-#ifdef WIN32
+#ifdef _WIN32
     LPSECURITY_ATTRIBUTES security_attributes = nullptr; // => Default security attributes
     if (CreateDirectoryW(StrConvert::Utf8ToWide(local_path).c_str(), security_attributes) != 0)
     {
@@ -1621,7 +1621,7 @@ namespace fineftp
     return FtpMessage(FtpReplyCode::FILE_ACTION_COMPLETED, "Working directory changed to " + ftp_working_directory_);
   }
 
-#ifdef WIN32
+#ifdef _WIN32
   std::string FtpSession::GetLastErrorStr()
   {
     const DWORD error = GetLastError();
@@ -1652,5 +1652,5 @@ namespace fineftp
 
     return ""; 
   }
-#endif //WIN32
+#endif //_WIN32
 }

--- a/fineftp-server/src/ftp_session.h
+++ b/fineftp-server/src/ftp_session.h
@@ -15,9 +15,9 @@
 #include "user_database.h"
 #include "ftp_user.h"
 
-#ifdef WIN32
+#ifdef _WIN32
   #include "win_str_convert.h"
-#endif // WIN32
+#endif // _WIN32
 
 namespace fineftp
 {
@@ -162,13 +162,13 @@ namespace fineftp
 
     FtpMessage executeCWD(const std::string& param);
 
-#ifdef WIN32
+#ifdef _WIN32
     /**
      * @brief Returns Windows' GetLastError() as human readable string
      * @return The message of the last error
      */
     static std::string GetLastErrorStr();
-#endif // WIN32
+#endif // _WIN32
 
   ////////////////////////////////////////////////////////
   // Member variables

--- a/fineftp-server/src/win_str_convert.cpp
+++ b/fineftp-server/src/win_str_convert.cpp
@@ -1,12 +1,12 @@
 #include "win_str_convert.h" // IWYU pragma: associated
 
-#ifdef WIN32
+#ifdef _WIN32
   #define WIN32_LEAN_AND_MEAN
   #ifndef NOMINMAX
     #define NOMINMAX
   #endif
   #include <windows.h> // IWYU pragma: keep
-#endif // WIN32
+#endif // _WIN32
 
 #include <string>
 
@@ -14,7 +14,7 @@ namespace fineftp
 {
   namespace StrConvert
   {
-#ifdef WIN32
+#ifdef _WIN32
     std::string WideToAnsi(const std::wstring& wstr)
     {
       const int count = WideCharToMultiByte(CP_ACP, 0, wstr.c_str(), static_cast<int>(wstr.length()), nullptr, 0, nullptr, nullptr);

--- a/fineftp-server/src/win_str_convert.h
+++ b/fineftp-server/src/win_str_convert.h
@@ -4,7 +4,7 @@ namespace fineftp
 {
   namespace StrConvert
   {
-#ifdef WIN32
+#ifdef _WIN32
     std::string WideToAnsi(const std::wstring& wstr);
 
     std::wstring AnsiToWide(const std::string& str);
@@ -16,6 +16,6 @@ namespace fineftp
     std::string AnsiToUtf8(const std::string& str);
 
     std::string Utf8ToAnsi(const std::string& str);
-#endif // WIN32
+#endif // _WIN32
   }
 }

--- a/samples/fineftp_example/src/main.cpp
+++ b/samples/fineftp_example/src/main.cpp
@@ -6,11 +6,11 @@
 
 int main() {
 
-#ifdef WIN32
+#ifdef _WIN32
   const std::string local_root =  "C:\\"; // The backslash at the end is necessary!
-#else // WIN32
+#else // _WIN32
   const std::string local_root =  "/";
-#endif // WIN32
+#endif // _WIN32
 
   // Create an FTP Server on port 2121. We use 2121 instead of the default port
   // 21, as your application would need root privileges to open port 21.

--- a/tests/fineftp_test/src/fineftp_stresstest.cpp
+++ b/tests/fineftp_test/src/fineftp_stresstest.cpp
@@ -16,9 +16,9 @@
 #include <thread>
 #include <vector>
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <win_str_convert.h>
-#endif // WIN32
+#endif // _WIN32
 
 #if 1
 TEST(FineFTPTest, SimpleUploadDownload) {
@@ -373,11 +373,11 @@ TEST(FineFTPTest, ListAndRename)
                               auto upload_target_filename = std::to_string(i) + "_" + std::to_string(j) + ".txt";
                               auto rename_target_filename = std::to_string(i) + "_" + std::to_string(j) + "_renamed.txt";
 
-#ifdef WIN32
+#ifdef _WIN32
                               const std::string curl_output_file = "NUL";
-#else // WIN32
+#else // _WIN32
                               const std::string curl_output_file = "/dev/null";
-#endif // WIN32
+#endif // _WIN32
 
                               const std::string curl_command = "curl -Q \"RNFR " + upload_target_filename + "\" "
                                                               + " -Q \"RNTO " + rename_target_filename + "\" "
@@ -887,22 +887,22 @@ TEST(FineFTPTest, UTF8Paths)
 
   const std::string upload_subdir_utf8 = "dir_" + utf8_laughing_emoji + utf8_german_letter_UE;
   const std::string filename_utf8      = "file_" + utf8_beermug_emoji + utf8_greek_letter_OMEGA + ".txt";
-#ifdef WIN32
+#ifdef _WIN32
   const std::wstring upload_subdir_wstr = fineftp::StrConvert::Utf8ToWide(upload_subdir_utf8);
   const std::wstring filename_wstr      = fineftp::StrConvert::Utf8ToWide(filename_utf8);
-#endif // WIN32
+#endif // _WIN32
 
-#ifdef WIN32
+#ifdef _WIN32
   // For Windows we need to use the wstring / UTF-16 functions to be independent from the system configuration
   const auto upload_subdir   = upload_dir / upload_subdir_wstr;
   const auto local_file_path = upload_subdir / filename_wstr;
   const std::string local_file_path_utf8 = fineftp::StrConvert::WideToUtf8(local_file_path.wstring());
-#else // WIN32
+#else // _WIN32
   // For all other operating systems we assume that they use UTF-8 out of the box
   const auto upload_subdir   = upload_dir / upload_subdir_utf8;
   const auto local_file_path = upload_subdir / filename_utf8;
   const std::string local_file_path_utf8 = local_file_path.string();
-#endif // WIN32
+#endif // _WIN32
 
   // Create local root and ftp dir
   {
@@ -939,11 +939,11 @@ TEST(FineFTPTest, UTF8Paths)
 
   // Create a small hello world file in the upload dir
   {
-#ifdef WIN32
+#ifdef _WIN32
     std::ofstream ofs(local_file_path.wstring());
-#else // WIN32
+#else // _WIN32
     std::ofstream ofs(local_file_path.string());
-#endif // WIN32
+#endif // _WIN32
     ofs << "Hello World";
     ofs.close();
     
@@ -955,13 +955,13 @@ TEST(FineFTPTest, UTF8Paths)
   // Upload the upload dir to the server with curl. Make sure to let curl create subdirs automatically
   {
     const std::string curl_command_utf8 = "curl  -S -s -T \"" + local_file_path_utf8 + "\" \"ftp://localhost:2121/" + utf8_laughing_emoji + "/\" --ftp-create-dirs";
-#ifdef WIN32
+#ifdef _WIN32
     const auto curl_result = _wsystem(fineftp::StrConvert::Utf8ToWide(curl_command_utf8).c_str());
     const auto target_file_path_in_ftp_root = ftp_root_dir / fineftp::StrConvert::Utf8ToWide(utf8_laughing_emoji) / filename_wstr;
 #else
     const auto curl_result = std::system(curl_command_utf8.c_str());
     const auto target_file_path_in_ftp_root = ftp_root_dir / utf8_laughing_emoji / filename_utf8;
-#endif // WIN32
+#endif // _WIN32
 
     ASSERT_EQ(curl_result, 0);
 
@@ -973,13 +973,13 @@ TEST(FineFTPTest, UTF8Paths)
   // Download the file again to the download dir.
   {
     const std::string curl_command_download_utf8 = "curl  -S -s -o \"" + (download_dir / filename_utf8).string() + "\" \"ftp://localhost:2121/" + utf8_laughing_emoji + "/" + filename_utf8 + "\"";
-#ifdef WIN32
+#ifdef _WIN32
     const auto curl_result = _wsystem(fineftp::StrConvert::Utf8ToWide(curl_command_download_utf8).c_str());
     const auto target_file_path_in_download_dir = download_dir / filename_wstr;
 #else
     const auto curl_result = std::system(curl_command_download_utf8.c_str());
     const auto target_file_path_in_download_dir = download_dir / filename_utf8;
-#endif // WIN32
+#endif // _WIN32
 
     ASSERT_EQ(curl_result, 0);
     

--- a/tests/fineftp_test/src/permission_test.cpp
+++ b/tests/fineftp_test/src/permission_test.cpp
@@ -12,9 +12,9 @@
 #include <utility>
 #include <vector>
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <win_str_convert.h>
-#endif // WIN32
+#endif // _WIN32
 
 namespace
 {
@@ -30,9 +30,9 @@ namespace
   int system_execute(const std::string& command)
   {
     const int status = std::system(command.c_str());
-#ifdef WIN32
+#ifdef _WIN32
     return status;
-#else  // WIN32
+#else  // _WIN32
     if (WIFEXITED(status))
     {
       // Program has exited normally
@@ -43,7 +43,7 @@ namespace
       // Program has exited abnormally
       return -1;
     }
-#endif // WIN32
+#endif // _WIN32
 
   }
 
@@ -452,11 +452,11 @@ TEST(PermissionTest, RenameFile)
     const std::string ftp_source_path = "/" + dir_preparer.ftp_file_b1.string();
     const std::string ftp_target_path = "/" + dir_preparer.ftp_file_b1.string() + "_renamed.txt";
 
-#ifdef WIN32
+#ifdef _WIN32
                               const std::string curl_output_file = "NUL";
-#else // WIN32
+#else // _WIN32
                               const std::string curl_output_file = "/dev/null";
-#endif // WIN32
+#endif // _WIN32
 
     const std::string curl_command = "curl -Q \"RNFR " + ftp_source_path + "\" "
                                     + " -Q \"RNTO " + ftp_target_path + "\" "
@@ -527,11 +527,11 @@ TEST(PermissionTest, RenameDir)
     const std::string ftp_source_path = "/" + dir_preparer.ftp_subdir_b_full.string();
     const std::string ftp_target_path = "/" + dir_preparer.ftp_subdir_b_full.string() + "_renamed";
 
-#ifdef WIN32
+#ifdef _WIN32
                               const std::string curl_output_file = "NUL";
-#else // WIN32
+#else // _WIN32
                               const std::string curl_output_file = "/dev/null";
-#endif // WIN32
+#endif // _WIN32
 
     const std::string curl_command = "curl -Q \"RNFR " + ftp_source_path + "\" "
                                     + " -Q \"RNTO " + ftp_target_path + "\" "
@@ -589,11 +589,11 @@ TEST(PermissionTest, DeleteFile)
 
     const std::string ftp_source_path = "/" + dir_preparer.ftp_file_b1.string();
 
-#ifdef WIN32
+#ifdef _WIN32
                               const std::string curl_output_file = "NUL";
-#else // WIN32
+#else // _WIN32
                               const std::string curl_output_file = "/dev/null";
-#endif // WIN32
+#endif // _WIN32
 
     const std::string curl_command = "curl -Q \"DELE " + ftp_source_path + "\" "
                                     + " -S -s "
@@ -654,11 +654,11 @@ TEST(PermissionTest, DeleteEmptyDir)
 
     const std::string ftp_source_path = "/" + dir_preparer.ftp_subdir_a_empty.string();
 
-#ifdef WIN32
+#ifdef _WIN32
                               const std::string curl_output_file = "NUL";
-#else // WIN32
+#else // _WIN32
                               const std::string curl_output_file = "/dev/null";
-#endif // WIN32
+#endif // _WIN32
 
     const std::string curl_command = "curl -Q \"RMD " + ftp_source_path + "\" "
                                     + " -S -s "
@@ -936,11 +936,11 @@ TEST(PermissionTest, DeleteFullDirWithRMD)
 
   const std::string ftp_source_path = "/" + dir_preparer.ftp_subdir_b_full.string();
 
-#ifdef WIN32
+#ifdef _WIN32
                             const std::string curl_output_file = "NUL";
-#else // WIN32
+#else // _WIN32
                             const std::string curl_output_file = "/dev/null";
-#endif // WIN32
+#endif // _WIN32
 
   const std::string curl_command = "curl -Q \"RMD " + ftp_source_path + "\" "
                                   + " -S -s "
@@ -974,11 +974,11 @@ TEST(PermissionTest, DeleteDirWithDELE)
 
   const std::string ftp_source_path = "/" + dir_preparer.ftp_subdir_a_empty.string();
 
-#ifdef WIN32
+#ifdef _WIN32
                             const std::string curl_output_file = "NUL";
-#else // WIN32
+#else // _WIN32
                             const std::string curl_output_file = "/dev/null";
-#endif // WIN32
+#endif // _WIN32
 
   const std::string curl_command = "curl -Q \"DELE " + ftp_source_path + "\" "
                                   + " -S -s "
@@ -1073,11 +1073,11 @@ TEST(PermissionTest, RenameNonExistingFile)
 
   const std::string ftp_source_path = "/" + dir_preparer.ftp_subdir_b_full.string();
 
-#ifdef WIN32
+#ifdef _WIN32
                             const std::string curl_output_file = "NUL";
-#else // WIN32
+#else // _WIN32
                             const std::string curl_output_file = "/dev/null";
-#endif // WIN32
+#endif // _WIN32
 
   const std::string curl_command = std::string("curl -Q \"RNFR /nonexisting_file\" ")
                                   + " -Q \"RNTO /someotherfile\" "
@@ -1106,11 +1106,11 @@ TEST(PermissionTest, RenameTargetExistsAlready)
 
   const std::string ftp_source_path = "/" + dir_preparer.ftp_subdir_b_full.string();
 
-#ifdef WIN32
+#ifdef _WIN32
                             const std::string curl_output_file = "NUL";
-#else // WIN32
+#else // _WIN32
                             const std::string curl_output_file = "/dev/null";
-#endif // WIN32
+#endif // _WIN32
 
   const std::string rename_source_file = "/" + dir_preparer.ftp_file_b1.string();
   const std::string rename_target_file = "/" + dir_preparer.ftp_file_b2.string();
@@ -1159,11 +1159,11 @@ TEST(PermissionTest, DeleteNonExistingWithDELE)
 
   const std::string ftp_source_path = "/" + dir_preparer.ftp_subdir_b_full.string();
 
-#ifdef WIN32
+#ifdef _WIN32
                             const std::string curl_output_file = "NUL";
-#else // WIN32
+#else // _WIN32
                             const std::string curl_output_file = "/dev/null";
-#endif // WIN32
+#endif // _WIN32
 
   const std::string curl_command = std::string("curl -Q \"DELE /nonexisting_file.txt\" ")
                                   + " -S -s "
@@ -1191,11 +1191,11 @@ TEST(PermissionTest, DeleteNonExistingWithRMD)
 
   const std::string ftp_source_path = "/" + dir_preparer.ftp_subdir_b_full.string();
 
-#ifdef WIN32
+#ifdef _WIN32
                             const std::string curl_output_file = "NUL";
-#else // WIN32
+#else // _WIN32
                             const std::string curl_output_file = "/dev/null";
-#endif // WIN32
+#endif // _WIN32
 
   const std::string curl_command = std::string("curl -Q \"RMD /nonexisting_dir\" ")
                                   + " -S -s "


### PR DESCRIPTION
The underscore version of the preprocessor macro is the safer option to use