### PR TITLE
Adding Support for MDTM command

### DIFF
--- a/fineftp-server/src/filesystem.h
+++ b/fineftp-server/src/filesystem.h
@@ -55,6 +55,8 @@ namespace fineftp
 
       std::string timeString() const;
 
+      std::string generalizedTimeString() const;
+
       bool canOpenDir() const;
 
 

--- a/fineftp-server/src/ftp_session.cpp
+++ b/fineftp-server/src/ftp_session.cpp
@@ -1180,6 +1180,7 @@ namespace fineftp
     ss << "211- Feature List:\r\n";
     ss << " UTF8\r\n";
     ss << " SIZE\r\n";
+    ss << " MDTM\r\n";
     ss << " LANG EN\r\n";
     ss << "211 END\r\n";
 

--- a/fineftp-server/src/ftp_session.h
+++ b/fineftp-server/src/ftp_session.h
@@ -109,6 +109,8 @@ namespace fineftp
 
     void handleFtpCommandOPTS(const std::string& param);
 
+    void handleFtpCommandMDTM(const std::string& param);
+
   ////////////////////////////////////////////////////////
   // FTP data-socket send
   ////////////////////////////////////////////////////////


### PR DESCRIPTION
**Summary**
This PR adds support for the MDTM (Modification Time) command as requested in [issue #47](https://github.com/ashhermirza/fineftp-server#47).
The MDTM command allows clients to retrieve the last modification time of a file on the server.

**Details**
Implemented handling for the MDTM FTP command.
Ensures correct timestamp format (YYYYMMDDHHMMSS) as per RFC 3659.
Added error handling for non-existent or non-retrievable files.

**Testing**
Tested on a Linux machine using FileZilla as the FTP client.

**Results**
```
FTP << MDTM /home/ashhermirza/Documents/test_file.txt
FTP >> 213 20251014111112

FTP << MDTM /home/ashhermirza/Documents/get-pip.py
FTP >> 213 20251012230103.073

FTP << MDTM /home/ashhermirza/Documents/
FTP >> 550 /home/ashhermirza/Documents is not retrievable

FTP << MTDM /home/ashhermirza/Documents/NoSuchFile
FTP >> 500 Unrecognized command

FTP << MDTM /home/ashhermirza/Documents/NoSuchFile
FTP >> 550 /home/ashhermirza/Documents/NoSuchFile is not retrievable
```

FEAT Response for MDTM

```
FTP << FEAT
FTP >> 211- Feature List:
 UTF8
 SIZE
 MDTM
 LANG EN
211 END
```
✅ Confirmed correct timestamps for valid files and appropriate 550 response for invalid paths.