### PR TITLE
Adding the missing private label

### DIFF
--- a/fineftp-server/src/unix/file_man.h
+++ b/fineftp-server/src/unix/file_man.h
@@ -101,6 +101,7 @@ public:
     return file_stream_.good();
   }
 
+private:
   std::fstream      file_stream_;
   std::vector<char> stream_buffer_;
 };


### PR DESCRIPTION
Adding `private` label to the `WriteableFile` class definition.

Test:
* Build tested on linux machine.